### PR TITLE
Move external-secrets helm chart to `external-secrets` namespace

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -24,6 +24,29 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.17.0"
+  hashes = [
+    "h1:0LSHBFqJvHTzQesUwagpDLsrzVliY+t2c26nDJizHFM=",
+    "h1:If79Gw54AMearm13Sk9RmWuDesCQQMUtmlJXXqISxfU=",
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "h1:rsqAO9oKyDMLiysQqrWEzf9CNtU9NJtwEGk7bSItC9g=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -47,6 +47,29 @@ provider "registry.terraform.io/hashicorp/helm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.35.1"
+  hashes = [
+    "h1:Av0Wk8g2XjY2oap7nyWNHEgfCRfphdJvrkqJjEM2ZKM=",
+    "h1:HqlQaR9X1IeZ2WNdDEvt7rq9iVuBll54SpWOE5bYmZ0=",
+    "h1:MfYq1y/cHyf7Xa1Bjw6bz/Z3PY4wgh92M+PAUJTj9qQ=",
+    "h1:x7Bb7kdixY66IPiCS+j651B47lWbABxptqt9V8rNLGc=",
+    "h1:zgXeWvp4//Ry+4glwNrLMpPFOU8QBQlARNmR9WCNe9o=",
+    "zh:12212ca5ae47823ce14bfafb909eeb6861faf1e2435fb2fc4a8b334b3544b5f5",
+    "zh:3f49b3d77182df06b225ab266667de69681c2e75d296867eb2cf06a8f8db768c",
+    "zh:40832494d19f8a2b3cd0c18b80294d0b23ef6b82f6f6897b5fe00248a9997460",
+    "zh:739a5ddea61a77925ee7006a29c8717377a2e9d0a79a0bbd98738d92eec12c0d",
+    "zh:a02b472021753627c5c39447a56d125a32214c29ff9108fc499f2dcdf4f1cc4f",
+    "zh:b78865b3867065aa266d6758c9601a2756741478f5735a838c20d633d65e085b",
+    "zh:d362e87464683f5632790e66920ea803adb54c2bc0cb24b6fd9a314d2b1efffd",
+    "zh:d98206fe88c2c9a52b8d2d0cb2c877c812a4a51d19f9d8428e63cbd5fd8a304d",
+    "zh:dfa320946b1ce3f3615c42b3447a28dc9f604c06d8b9a6fe289855ab2ade4d11",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc1debd2e695b5222d2ccc8b24dab65baba4ee2418ecce944e64d42e79474cb5",
+    "zh:fdaf960443720a238c09e519aeb30faf74f027ac5d1e0a309c3b326888e031d7",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.16 (Jan 29, 2025)
+* Moved `external-secrets` helm chart into this TF module. 
+
 # 0.3.15 (Dec 13, 2024)
 * Revert unknown Service Account Config on k8s cluster.
 

--- a/gsm-secrets.tf
+++ b/gsm-secrets.tf
@@ -1,3 +1,5 @@
+// TODO: Migrate to using built-in SecretsManager support from Google
+
 locals {
   cluster_id             = google_container_cluster.primary.id
   cluster_name           = google_container_cluster.primary.name
@@ -15,6 +17,13 @@ provider "helm" {
   }
 }
 
+// We are going to configure the kubernetes cluster with a secrets store
+// This secrets store will provide storage of secrets in google secrets manager instead of kubernetes storage
+// We found two libraries to achieve:
+//   - Secrets Store CSI Driver: https://secrets-store-csi-driver.sigs.k8s.io/
+//   - External Secrets Operator (ESO): https://external-secrets.io/
+// Secrets Store CSI Driver is mentioned by the Google Cloud docs; however, their documentation is poor with limited driver support
+// ESO has extensive documentation, broad secret provider support, and generators (not used yet, but could be useful to teams)
 resource "helm_release" "gsm-external-secrets" {
   name       = "external-secrets"
   repository = "https://charts.external-secrets.io"

--- a/gsm-secrets.tf
+++ b/gsm-secrets.tf
@@ -1,0 +1,23 @@
+locals {
+  cluster_id             = google_container_cluster.primary.id
+  cluster_name           = google_container_cluster.primary.name
+  cluster_endpoint       = google_container_cluster.primary.endpoint
+  cluster_ca_certificate = google_container_cluster.primary.master_auth.0.cluster_ca_certificate
+}
+
+data "google_client_config" "provider" {}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${local.cluster_endpoint}"
+    token                  = data.google_client_config.provider.access_token
+    cluster_ca_certificate = base64decode(local.cluster_ca_certificate)
+  }
+}
+
+resource "helm_release" "gsm-external-secrets" {
+  name       = "external-secrets"
+  repository = "https://charts.external-secrets.io"
+  chart      = "external-secrets"
+  namespace  = "external-secrets"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,8 @@ variable "max_node_count" {
 }
 
 variable "num_node_zones" {
-  type    = number
-  default = 2
+  type        = number
+  default     = 2
   description = <<EOF
 The number of zones to allocate GKE Nodes.
 This works in combination with min_node_count, max_node_count to determine how many nodes to create.


### PR DESCRIPTION
In coordination with https://github.com/nullstone-modules/gcp-gke-namespace/pull/2